### PR TITLE
Disable shift horizontal scroll

### DIFF
--- a/UnnaturalScrollWheels/Base.lproj/Main.storyboard
+++ b/UnnaturalScrollWheels/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -81,36 +81,49 @@
             <objects>
                 <viewController id="EeT-in-kJF" customClass="PreferencesViewController" customModule="UnnaturalScrollWheels" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="Tpp-gi-8q5">
-                        <rect key="frame" x="0.0" y="0.0" width="400" height="375"/>
+                        <rect key="frame" x="0.0" y="0.0" width="400" height="399"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <subviews>
                             <stackView distribution="fillEqually" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4Gb-2g-xS1">
-                                <rect key="frame" x="20" y="20" width="360" height="335"/>
+                                <rect key="frame" x="20" y="20" width="360" height="359"/>
                                 <subviews>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pq8-4N-iLQ">
-                                        <rect key="frame" x="-2" y="318" width="179" height="18"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="16" id="ADb-uv-XNX"/>
-                                        </constraints>
+                                        <rect key="frame" x="-2" y="342" width="179" height="18"/>
                                         <buttonCell key="cell" type="check" title="Invert horizontal scrolling" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="THg-pv-IgQ">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="16" id="ADb-uv-XNX"/>
+                                        </constraints>
                                         <connections>
                                             <action selector="invertHorizontalScrollClicked:" target="EeT-in-kJF" id="VQv-q1-BYZ"/>
                                         </connections>
                                     </button>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jGQ-7c-3yZ">
-                                        <rect key="frame" x="-2" y="294" width="164" height="18"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="16" id="gU9-hz-xJn"/>
-                                        </constraints>
+                                        <rect key="frame" x="-2" y="318" width="164" height="18"/>
                                         <buttonCell key="cell" type="check" title="Invert vertical scrolling" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="CRi-ml-BgH">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="16" id="gU9-hz-xJn"/>
+                                        </constraints>
                                         <connections>
                                             <action selector="invertVerticalScrollClicked:" target="EeT-in-kJF" id="xVH-v2-hh4"/>
+                                        </connections>
+                                    </button>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="48c-1d-g01" userLabel="Disable horizontal scroll">
+                                        <rect key="frame" x="-2" y="294" width="201" height="18"/>
+                                        <buttonCell key="cell" type="check" title="Disable shift horizontal scroll" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="FIM-ud-OZb">
+                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="16" id="ERp-Ac-du0"/>
+                                        </constraints>
+                                        <connections>
+                                            <action selector="disableHorizontalScrollClicked:" target="EeT-in-kJF" id="2eU-zZ-Mw2"/>
                                         </connections>
                                     </button>
                                     <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="JFi-ui-cJO">
@@ -121,13 +134,13 @@
                                     </box>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="w54-Ka-oAh">
                                         <rect key="frame" x="-2" y="252" width="185" height="18"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="16" id="vwG-mg-0Nt"/>
-                                        </constraints>
                                         <buttonCell key="cell" type="check" title="Disable scroll acceleration" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="2qg-mY-yJ4">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="16" id="vwG-mg-0Nt"/>
+                                        </constraints>
                                         <connections>
                                             <action selector="disableScrollAccelClicked:" target="EeT-in-kJF" id="7Xl-Gj-Bdm"/>
                                         </connections>
@@ -146,7 +159,7 @@
                                                     <action selector="scrollLinesStepperPressed:" target="EeT-in-kJF" id="ibT-Uh-6UO"/>
                                                 </connections>
                                             </stepper>
-                                            <textField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wQb-x1-J78">
+                                            <textField focusRingType="none" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wQb-x1-J78">
                                                 <rect key="frame" x="21" y="1" width="17" height="21"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="21" id="89Q-xG-Iph"/>
@@ -158,7 +171,7 @@
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
                                             </textField>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YRf-tJ-Kwv">
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YRf-tJ-Kwv">
                                                 <rect key="frame" x="44" y="3" width="246" height="16"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="16" id="zNE-U5-UMu"/>
@@ -192,31 +205,31 @@
                                     </box>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="CEh-IB-fcI">
                                         <rect key="frame" x="-2" y="180" width="119" height="18"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="16" id="Emt-wl-XYu"/>
-                                        </constraints>
                                         <buttonCell key="cell" type="check" title="Launch at login" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="yjP-KS-Mki">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="16" id="Emt-wl-XYu"/>
+                                        </constraints>
                                         <connections>
                                             <action selector="launchAtLogin:" target="EeT-in-kJF" id="yWu-hE-PMA"/>
                                         </connections>
                                     </button>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WC9-Vk-b88">
                                         <rect key="frame" x="-2" y="156" width="193" height="18"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="16" id="pHm-eR-xzm"/>
-                                        </constraints>
                                         <buttonCell key="cell" type="check" title="Alternate detection method" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="fpD-L1-Nvz">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="16" id="pHm-eR-xzm"/>
+                                        </constraints>
                                         <connections>
                                             <action selector="alternateDetectionMethodClicked:" target="EeT-in-kJF" id="EGD-3a-Ipe"/>
                                         </connections>
                                     </button>
-                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="32c-TO-HCl">
+                                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="32c-TO-HCl">
                                         <rect key="frame" x="-2" y="136" width="247" height="13"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="13" id="EEt-Zg-Acg"/>
@@ -229,18 +242,18 @@
                                     </textField>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zKl-6W-QQK">
                                         <rect key="frame" x="-2" y="111" width="193" height="18"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="16" id="QeP-pg-trR"/>
-                                        </constraints>
                                         <buttonCell key="cell" type="check" title="Disable mouse acceleration" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="uBt-a0-G5E">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="16" id="QeP-pg-trR"/>
+                                        </constraints>
                                         <connections>
                                             <action selector="disableMouseAccelClicked:" target="EeT-in-kJF" id="wGD-8i-aFj"/>
                                         </connections>
                                     </button>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oUF-V2-P7R">
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oUF-V2-P7R">
                                         <rect key="frame" x="-2" y="91" width="139" height="13"/>
                                         <textFieldCell key="cell" title="1:1 mouse/cursor movement" id="YfG-ae-gyc">
                                             <font key="font" metaFont="system" size="10"/>
@@ -250,18 +263,18 @@
                                     </textField>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dNO-k4-DXG">
                                         <rect key="frame" x="-2" y="66" width="149" height="18"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="16" id="Sx7-ip-Q8Z"/>
-                                        </constraints>
                                         <buttonCell key="cell" type="check" title="Show menu bar icon" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="S1r-5q-wwg">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="16" id="Sx7-ip-Q8Z"/>
+                                        </constraints>
                                         <connections>
                                             <action selector="showMenuBarItem:" target="EeT-in-kJF" id="7bt-eT-jYr"/>
                                         </connections>
                                     </button>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sAx-Nf-FB0">
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sAx-Nf-FB0">
                                         <rect key="frame" x="-2" y="46" width="284" height="13"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="If disabled, open the app from Finder to show preferences" id="3iq-1l-Jxb">
                                             <font key="font" metaFont="system" size="10"/>
@@ -361,8 +374,10 @@ DQ
                                     <integer value="1000"/>
                                     <integer value="1000"/>
                                     <integer value="1000"/>
+                                    <integer value="1000"/>
                                 </visibilityPriorities>
                                 <customSpacing>
+                                    <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
@@ -390,6 +405,7 @@ DQ
                     </view>
                     <connections>
                         <outlet property="alternateDetectionMethod" destination="WC9-Vk-b88" id="pgG-Tc-HGO"/>
+                        <outlet property="disableHorizontalScroll" destination="48c-1d-g01" id="Eah-FV-fee"/>
                         <outlet property="disableMouseAccel" destination="zKl-6W-QQK" id="Y6Q-Vh-qrg"/>
                         <outlet property="disableScrollAccel" destination="w54-Ka-oAh" id="EpQ-W5-geK"/>
                         <outlet property="invertHorizontalScroll" destination="pq8-4N-iLQ" id="zdm-WB-PHS"/>

--- a/UnnaturalScrollWheels/Options.swift
+++ b/UnnaturalScrollWheels/Options.swift
@@ -15,6 +15,7 @@ class Options {
     var showMenuBarIcon: Bool = true
     var invertVerticalScroll: Bool = true
     var invertHorizontalScroll: Bool = false
+    var disableShiftHorizontalScroll: Bool = false
     var disableScrollAccel: Bool = true
     var scrollLines: Int64 = 3
     var alternateDetectionMethod: Bool = false
@@ -30,6 +31,9 @@ class Options {
         }
         if UserDefaults.standard.object(forKey: "InvertVerticalScroll") == nil {
             UserDefaults.standard.set(invertVerticalScroll, forKey: "InvertVerticalScroll")
+        }
+        if UserDefaults.standard.object(forKey: "DisableShiftHorizontalScroll") == nil {
+            UserDefaults.standard.set(disableShiftHorizontalScroll, forKey: "DisableShiftHorizontalScroll")
         }
         if UserDefaults.standard.object(forKey: "InvertHorizonalScroll") == nil {
             UserDefaults.standard.set(invertHorizontalScroll, forKey: "InvertHorizonalScroll")
@@ -60,6 +64,7 @@ class Options {
         showMenuBarIcon = UserDefaults.standard.bool(forKey: "ShowMenuBarIcon")
         invertVerticalScroll = UserDefaults.standard.bool(forKey: "InvertVerticalScroll")
         invertHorizontalScroll = UserDefaults.standard.bool(forKey: "InvertHorizontalScroll")
+        disableShiftHorizontalScroll = UserDefaults.standard.bool(forKey: "DisableShiftHorizontalScroll")
         disableScrollAccel = UserDefaults.standard.bool(forKey: "DisableScrollAccel")
         scrollLines = Int64(UserDefaults.standard.integer(forKey: "ScrollLines"))
         alternateDetectionMethod = UserDefaults.standard.bool(forKey: "AlternateDetectionMethod")

--- a/UnnaturalScrollWheels/PreferencesViewController.swift
+++ b/UnnaturalScrollWheels/PreferencesViewController.swift
@@ -12,6 +12,7 @@ import ServiceManagement
 class PreferencesViewController: NSViewController {
     @IBOutlet weak var invertVerticalScroll: NSButton?
     @IBOutlet weak var invertHorizontalScroll: NSButton?
+    @IBOutlet weak var disableHorizontalScroll: NSButton!
     @IBOutlet weak var disableScrollAccel: NSButton?
     @IBOutlet weak var scrollLinesText: NSTextField?
     @IBOutlet weak var scrollLines: NSStepper?
@@ -25,6 +26,7 @@ class PreferencesViewController: NSViewController {
         super.viewDidLoad()
         invertVerticalScroll?.takeIntValueFrom(Options.shared.invertVerticalScroll)
         invertHorizontalScroll?.takeIntValueFrom(Options.shared.invertHorizontalScroll)
+        disableHorizontalScroll?.takeIntValueFrom(Options.shared.disableShiftHorizontalScroll)
         disableScrollAccel?.takeIntValueFrom(Options.shared.disableScrollAccel)
         scrollLines?.takeIntValueFrom(Options.shared.scrollLines)
         scrollLinesText?.takeStringValueFrom(scrollLines?.integerValue)
@@ -44,6 +46,10 @@ class PreferencesViewController: NSViewController {
     
     @IBAction func invertVerticalScrollClicked(_ sender: Any) {
         Options.shared.invertVerticalScroll = !Options.shared.invertVerticalScroll
+    }
+    
+    @IBAction func disableHorizontalScrollClicked(_ sender: Any) {
+        Options.shared.disableShiftHorizontalScroll = !Options.shared.disableShiftHorizontalScroll
     }
     
     @IBAction func disableScrollAccelClicked(_ sender: Any) {
@@ -78,6 +84,7 @@ class PreferencesViewController: NSViewController {
     @IBAction func applyPreferences(_ sender: Any) {
         UserDefaults.standard.set(invertVerticalScroll?.state == NSControl.StateValue.on, forKey: "InvertVerticalScroll")
         UserDefaults.standard.set(invertHorizontalScroll?.state == NSControl.StateValue.on, forKey: "InvertHorizontalScroll")
+        UserDefaults.standard.set(disableHorizontalScroll?.state == NSControl.StateValue.on, forKey: "DisableShiftHorizontalScroll")
         UserDefaults.standard.set(disableScrollAccel?.state == NSControl.StateValue.on, forKey: "DisableScrollAccel")
         UserDefaults.standard.set(scrollLines?.integerValue, forKey: "ScrollLines")
         UserDefaults.standard.set(alternateDetectionMethod?.state == NSControl.StateValue.on, forKey: "AlternateDetectionMethod")

--- a/UnnaturalScrollWheels/ScrollInterceptor.swift
+++ b/UnnaturalScrollWheels/ScrollInterceptor.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreGraphics
 
 class ScrollInterceptor {
     
@@ -48,6 +49,11 @@ class ScrollInterceptor {
                 event.setIntegerValueField(
                     .scrollWheelEventDeltaAxis2, value: -event.getIntegerValueField(.scrollWheelEventDeltaAxis2))
             }
+            
+            if Options.shared.disableShiftHorizontalScroll {
+                event.flags.remove(.maskShift)
+            }
+        
             // Disable scroll acceleration
             if Options.shared.disableScrollAccel {
                 event.setIntegerValueField(.scrollWheelEventDeltaAxis1, value: event.getIntegerValueField(.scrollWheelEventDeltaAxis1).signum() * Options.shared.scrollLines)

--- a/UnnaturalScrollWheels/en.lproj/Main.storyboard
+++ b/UnnaturalScrollWheels/en.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -81,36 +81,49 @@
             <objects>
                 <viewController id="EeT-in-kJF" customClass="PreferencesViewController" customModule="UnnaturalScrollWheels" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="Tpp-gi-8q5">
-                        <rect key="frame" x="0.0" y="0.0" width="400" height="375"/>
+                        <rect key="frame" x="0.0" y="0.0" width="400" height="399"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <subviews>
                             <stackView distribution="fillEqually" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4Gb-2g-xS1">
-                                <rect key="frame" x="20" y="20" width="360" height="335"/>
+                                <rect key="frame" x="20" y="20" width="360" height="359"/>
                                 <subviews>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pq8-4N-iLQ">
-                                        <rect key="frame" x="-2" y="318" width="179" height="18"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="16" id="ADb-uv-XNX"/>
-                                        </constraints>
+                                        <rect key="frame" x="-2" y="342" width="179" height="18"/>
                                         <buttonCell key="cell" type="check" title="Invert horizontal scrolling" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="THg-pv-IgQ">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="16" id="ADb-uv-XNX"/>
+                                        </constraints>
                                         <connections>
                                             <action selector="invertHorizontalScrollClicked:" target="EeT-in-kJF" id="VQv-q1-BYZ"/>
                                         </connections>
                                     </button>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jGQ-7c-3yZ">
-                                        <rect key="frame" x="-2" y="294" width="164" height="18"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="16" id="gU9-hz-xJn"/>
-                                        </constraints>
+                                        <rect key="frame" x="-2" y="318" width="164" height="18"/>
                                         <buttonCell key="cell" type="check" title="Invert vertical scrolling" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="CRi-ml-BgH">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="16" id="gU9-hz-xJn"/>
+                                        </constraints>
                                         <connections>
                                             <action selector="invertVerticalScrollClicked:" target="EeT-in-kJF" id="xVH-v2-hh4"/>
+                                        </connections>
+                                    </button>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1AT-HI-EOm" userLabel="Disable horizontal scroll">
+                                        <rect key="frame" x="-2" y="294" width="201" height="18"/>
+                                        <buttonCell key="cell" type="check" title="Disable shift horizontal scroll" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Xpp-FM-eVr">
+                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="16" id="lnY-nl-GZh"/>
+                                        </constraints>
+                                        <connections>
+                                            <action selector="disableHorizontalScrollClicked:" target="EeT-in-kJF" id="cK8-CF-RlK"/>
                                         </connections>
                                     </button>
                                     <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="JFi-ui-cJO">
@@ -121,13 +134,13 @@
                                     </box>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="w54-Ka-oAh">
                                         <rect key="frame" x="-2" y="252" width="185" height="18"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="16" id="vwG-mg-0Nt"/>
-                                        </constraints>
                                         <buttonCell key="cell" type="check" title="Disable scroll acceleration" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="2qg-mY-yJ4">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="16" id="vwG-mg-0Nt"/>
+                                        </constraints>
                                         <connections>
                                             <action selector="disableScrollAccelClicked:" target="EeT-in-kJF" id="7Xl-Gj-Bdm"/>
                                         </connections>
@@ -146,7 +159,7 @@
                                                     <action selector="scrollLinesStepperPressed:" target="EeT-in-kJF" id="ibT-Uh-6UO"/>
                                                 </connections>
                                             </stepper>
-                                            <textField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wQb-x1-J78">
+                                            <textField focusRingType="none" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wQb-x1-J78">
                                                 <rect key="frame" x="21" y="1" width="17" height="21"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="21" id="89Q-xG-Iph"/>
@@ -158,7 +171,7 @@
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
                                             </textField>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YRf-tJ-Kwv">
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YRf-tJ-Kwv">
                                                 <rect key="frame" x="44" y="3" width="246" height="16"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="16" id="zNE-U5-UMu"/>
@@ -192,31 +205,31 @@
                                     </box>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="teo-9l-byg">
                                         <rect key="frame" x="-2" y="180" width="119" height="18"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="16" id="iVp-nG-eUb"/>
-                                        </constraints>
                                         <buttonCell key="cell" type="check" title="Launch at login" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="F1c-hA-ghI">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="16" id="iVp-nG-eUb"/>
+                                        </constraints>
                                         <connections>
                                             <action selector="launchAtLogin:" target="EeT-in-kJF" id="jb3-mA-nUQ"/>
                                         </connections>
                                     </button>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WC9-Vk-b88">
                                         <rect key="frame" x="-2" y="156" width="193" height="18"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="16" id="pHm-eR-xzm"/>
-                                        </constraints>
                                         <buttonCell key="cell" type="check" title="Alternate detection method" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="fpD-L1-Nvz">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="16" id="pHm-eR-xzm"/>
+                                        </constraints>
                                         <connections>
                                             <action selector="alternateDetectionMethodClicked:" target="EeT-in-kJF" id="EGD-3a-Ipe"/>
                                         </connections>
                                     </button>
-                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="32c-TO-HCl">
+                                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="32c-TO-HCl">
                                         <rect key="frame" x="-2" y="136" width="313" height="13"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="13" id="EEt-Zg-Acg"/>
@@ -229,18 +242,18 @@
                                     </textField>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zKl-6W-QQK">
                                         <rect key="frame" x="-2" y="111" width="193" height="18"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="16" id="QeP-pg-trR"/>
-                                        </constraints>
                                         <buttonCell key="cell" type="check" title="Disable mouse acceleration" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="uBt-a0-G5E">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="16" id="QeP-pg-trR"/>
+                                        </constraints>
                                         <connections>
                                             <action selector="disableMouseAccelClicked:" target="EeT-in-kJF" id="wGD-8i-aFj"/>
                                         </connections>
                                     </button>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oUF-V2-P7R">
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oUF-V2-P7R">
                                         <rect key="frame" x="-2" y="91" width="139" height="13"/>
                                         <textFieldCell key="cell" title="1:1 mouse/cursor movement" id="YfG-ae-gyc">
                                             <font key="font" metaFont="system" size="10"/>
@@ -250,18 +263,18 @@
                                     </textField>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dNO-k4-DXG">
                                         <rect key="frame" x="-2" y="66" width="149" height="18"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="16" id="Sx7-ip-Q8Z"/>
-                                        </constraints>
                                         <buttonCell key="cell" type="check" title="Show menu bar icon" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="S1r-5q-wwg">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="16" id="Sx7-ip-Q8Z"/>
+                                        </constraints>
                                         <connections>
                                             <action selector="showMenuBarItem:" target="EeT-in-kJF" id="7bt-eT-jYr"/>
                                         </connections>
                                     </button>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sAx-Nf-FB0">
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sAx-Nf-FB0">
                                         <rect key="frame" x="-2" y="46" width="284" height="13"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="If disabled, open the app from Finder to show preferences" id="3iq-1l-Jxb">
                                             <font key="font" metaFont="system" size="10"/>
@@ -361,8 +374,10 @@ DQ
                                     <integer value="1000"/>
                                     <integer value="1000"/>
                                     <integer value="1000"/>
+                                    <integer value="1000"/>
                                 </visibilityPriorities>
                                 <customSpacing>
+                                    <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
@@ -390,6 +405,7 @@ DQ
                     </view>
                     <connections>
                         <outlet property="alternateDetectionMethod" destination="WC9-Vk-b88" id="pgG-Tc-HGO"/>
+                        <outlet property="disableHorizontalScroll" destination="1AT-HI-EOm" id="Bcl-dt-ULx"/>
                         <outlet property="disableMouseAccel" destination="zKl-6W-QQK" id="Y6Q-Vh-qrg"/>
                         <outlet property="disableScrollAccel" destination="w54-Ka-oAh" id="EpQ-W5-geK"/>
                         <outlet property="invertHorizontalScroll" destination="pq8-4N-iLQ" id="zdm-WB-PHS"/>


### PR DESCRIPTION
Feature that disables macos shift+scroll = horizontal scroll event. 
Useful for mac gaming(wine doesnt register horizontal events and if you hold shift and scroll wine does nothing).
Since it is somewhat related to scrolling and I use your app daily I thought that such feature would fit and I will be very greatful if you would merge it.

Here's how it looks
<img width="396" alt="image" src="https://github.com/user-attachments/assets/d7b2f37b-c203-4512-bedc-29eb6966749d" />

If it is enabled it just removes .maskShift flag from CGEvent