### PR TITLE
Avoid duplicate event tap setup

### DIFF
--- a/UnnaturalScrollWheels/MenuBarItem.swift
+++ b/UnnaturalScrollWheels/MenuBarItem.swift
@@ -10,7 +10,7 @@ import Foundation
 import Cocoa
 
 class MenuBarItem {
-    
+
     static let shared = MenuBarItem()
     var statusItem: NSStatusItem?
     public var menu: NSMenu? {
@@ -26,16 +26,22 @@ class MenuBarItem {
             remove()
         }
     }
-    
+
     private func add() {
-        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        statusItem?.button?.title = "⭥"
-        statusItem?.menu = self.menu
+        guard statusItem == nil else {
+            statusItem?.menu = menu
+            return
+        }
+
+        let newStatusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        newStatusItem.button?.title = "⭥"
+        newStatusItem.menu = menu
+        statusItem = newStatusItem
     }
-    
+
     private func remove() {
         guard let statusItem = statusItem else { return }
         NSStatusBar.system.removeStatusItem(statusItem)
+        self.statusItem = nil
     }
 }
-

--- a/UnnaturalScrollWheels/ScrollInterceptor.swift
+++ b/UnnaturalScrollWheels/ScrollInterceptor.swift
@@ -10,11 +10,20 @@ import Foundation
 import CoreGraphics
 
 class ScrollInterceptor {
-    
+
     static let shared = ScrollInterceptor()
-    
+
+    private let stateLock = NSLock()
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+    private var isIntercepting = false
+
     // Where the magic happens
     let scrollEventCallback: CGEventTapCallBack = { (proxy: CGEventTapProxy, type: CGEventType, event: CGEvent, refcon) in
+        guard type == .scrollWheel else {
+            return Unmanaged.passUnretained(event)
+        }
+
         //        // Debugging
         //        // Usually 0 if scroll wheel unless Logitech Options or similar interferes
         //        print("Continuous: ", event.getIntegerValueField(.scrollWheelEventIsContinuous))
@@ -22,7 +31,7 @@ class ScrollInterceptor {
         //        print("MomentumPhase: ", event.getDoubleValueField(.scrollWheelEventMomentumPhase))
         //        print("ScrollCount: ", event.getDoubleValueField(.scrollWheelEventScrollCount))
         //        print("ScrollPhase: ", event.getDoubleValueField(.scrollWheelEventScrollPhase))
-        
+
         var isWheel: Bool = true
         if !Options.shared.alternateDetectionMethod {
             // scrollWheelEventIsContinuous will be 0 for mice and 1 for trackpads
@@ -38,7 +47,7 @@ class ScrollInterceptor {
                 isWheel = false
             }
         }
-        
+
         if isWheel {
             // Invert the scroll event
             if Options.shared.invertVerticalScroll {
@@ -57,14 +66,19 @@ class ScrollInterceptor {
         // pass the event to the system
         return Unmanaged.passUnretained(event)
     }
-    
+
     // Intercept scroll wheel events
     func interceptScroll() {
+        stateLock.lock()
+        guard !isIntercepting else {
+            stateLock.unlock()
+            return
+        }
+        isIntercepting = true
+        stateLock.unlock()
+
         DispatchQueue.global(qos: .userInteractive).async {
-            var eventTap: CFMachPort?
-            var runLoopSource: CFRunLoopSource?
-            
-            eventTap = CGEvent.tapCreate(
+            guard let eventTap = CGEvent.tapCreate(
                 tap: .cghidEventTap,
                 place: .tailAppendEventTap,
                 options: .defaultTap,
@@ -72,11 +86,38 @@ class ScrollInterceptor {
                 eventsOfInterest: CGEventMask(1 << CGEventType.scrollWheel.rawValue),
                 callback: self.scrollEventCallback,
                 userInfo: nil
-            )
-            runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
-            CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, CFRunLoopMode.commonModes)
-            CGEvent.tapEnable(tap: eventTap!, enable: true)
+            ) else {
+                self.clearInterceptionState()
+                return
+            }
+
+            guard let runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0) else {
+                CFMachPortInvalidate(eventTap)
+                self.clearInterceptionState()
+                return
+            }
+
+            self.stateLock.lock()
+            self.eventTap = eventTap
+            self.runLoopSource = runLoopSource
+            self.stateLock.unlock()
+
+            let runLoop = CFRunLoopGetCurrent()
+            CFRunLoopAddSource(runLoop, runLoopSource, CFRunLoopMode.commonModes)
+            CGEvent.tapEnable(tap: eventTap, enable: true)
             CFRunLoopRun()
+
+            CFRunLoopRemoveSource(runLoop, runLoopSource, CFRunLoopMode.commonModes)
+            CFMachPortInvalidate(eventTap)
+            self.clearInterceptionState()
         }
+    }
+
+    private func clearInterceptionState() {
+        stateLock.lock()
+        eventTap = nil
+        runLoopSource = nil
+        isIntercepting = false
+        stateLock.unlock()
     }
 }


### PR DESCRIPTION
## Summary

Tightens up a couple lifecycle paths:

- Don’t create a new menu bar item if one already exists
- Clear the stored menu bar item after removing it
- Make scroll interception setup a no-op if it is already running
- Avoid force-unwrapping event tap creation

This came out of looking into possible memory growth, so the changes are intentionally limited to making these long-lived resources less easy to duplicate.

## Testing

- Built locally with `xcodebuild`
- Ran `xcodebuild analyze`
