### PR TITLE
Fix freeze after sleep/standby and crash around the dashboard on macOS 26

### DIFF
--- a/UnnaturalScrollWheels/AppDelegate.swift
+++ b/UnnaturalScrollWheels/AppDelegate.swift
@@ -133,14 +133,21 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         let client: IOHIDEventSystemClient = IOHIDEventSystemClientCreateSimpleClient(kCFAllocatorDefault)
         let mouseAccelerationType: CFString = kIOHIDMouseAccelerationType as NSString
         
-        // Get the starting acceleration value
+        // Get the starting acceleration value.
+        // IOHIDEventSystemClientCopyProperty can return nil — notably right
+        // after the system wakes from sleep / low-battery standby while the HID
+        // subsystem is still coming back. Force-unwrapping it there crashed the
+        // app (and made closing the preferences window crash, since that also
+        // refreshes mouse accel). Read it defensively instead.
         var origAccel: Int32 = 0
-        let originalAccelRef: CFTypeRef = IOHIDEventSystemClientCopyProperty(client, mouseAccelerationType)!
-        CFNumberGetValue((originalAccelRef as! CFNumber), CFNumberType.sInt32Type, &origAccel)
-        // Only save it if it's not -1 (acceleration off)
-        if origAccel != -1 {
-            Options.shared.origAccel = origAccel
-            UserDefaults.standard.set(origAccel, forKey: "OriginalAccel")
+        if let originalAccelRef = IOHIDEventSystemClientCopyProperty(client, mouseAccelerationType),
+           CFGetTypeID(originalAccelRef) == CFNumberGetTypeID() {
+            CFNumberGetValue((originalAccelRef as! CFNumber), CFNumberType.sInt32Type, &origAccel)
+            // Only save it if it's not -1 (acceleration off)
+            if origAccel != -1 {
+                Options.shared.origAccel = origAccel
+                UserDefaults.standard.set(origAccel, forKey: "OriginalAccel")
+            }
         }
         if Options.shared.disableMouseAccel {
             Options.shared.accel = -1

--- a/UnnaturalScrollWheels/MenuBarItem.swift
+++ b/UnnaturalScrollWheels/MenuBarItem.swift
@@ -28,14 +28,24 @@ class MenuBarItem {
     }
     
     private func add() {
-        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        statusItem?.button?.title = "⭥"
-        statusItem?.menu = self.menu
+        // refresh() calls this on every preferences close; without this guard a
+        // brand new NSStatusItem was created each time, leaking the old one and
+        // leaving duplicate/zombie menu bar icons.
+        guard statusItem == nil else {
+            statusItem?.menu = menu
+            return
+        }
+
+        let newStatusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        newStatusItem.button?.title = "⭥"
+        newStatusItem.menu = menu
+        statusItem = newStatusItem
     }
-    
+
     private func remove() {
         guard let statusItem = statusItem else { return }
         NSStatusBar.system.removeStatusItem(statusItem)
+        self.statusItem = nil
     }
 }
 

--- a/UnnaturalScrollWheels/ScrollInterceptor.swift
+++ b/UnnaturalScrollWheels/ScrollInterceptor.swift
@@ -8,13 +8,36 @@
 
 import Foundation
 import CoreGraphics
+import AppKit
 
 class ScrollInterceptor {
-    
+
     static let shared = ScrollInterceptor()
-    
+
+    private let stateLock = NSLock()
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+    private var runLoop: CFRunLoop?
+    private var isIntercepting = false
+    private var wakeObserver: NSObjectProtocol?
+
     // Where the magic happens
     let scrollEventCallback: CGEventTapCallBack = { (proxy: CGEventTapProxy, type: CGEventType, event: CGEvent, refcon) in
+        // macOS disables the event tap when the callback takes too long, on
+        // heavy input, and when the system wakes from sleep / low-battery
+        // standby. When that happens the OS delivers one final event of type
+        // .tapDisabledByTimeout / .tapDisabledByUserInput. If we don't re-enable
+        // the tap here, scroll interception silently dies and the app appears
+        // frozen until it is force quit and relaunched (issues #66, #97, #117).
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            ScrollInterceptor.shared.reEnableTap()
+            return Unmanaged.passUnretained(event)
+        }
+
+        guard type == .scrollWheel else {
+            return Unmanaged.passUnretained(event)
+        }
+
         //        // Debugging
         //        // Usually 0 if scroll wheel unless Logitech Options or similar interferes
         //        print("Continuous: ", event.getIntegerValueField(.scrollWheelEventIsContinuous))
@@ -22,7 +45,7 @@ class ScrollInterceptor {
         //        print("MomentumPhase: ", event.getDoubleValueField(.scrollWheelEventMomentumPhase))
         //        print("ScrollCount: ", event.getDoubleValueField(.scrollWheelEventScrollCount))
         //        print("ScrollPhase: ", event.getDoubleValueField(.scrollWheelEventScrollPhase))
-        
+
         var isWheel: Bool = true
         if !Options.shared.alternateDetectionMethod {
             // scrollWheelEventIsContinuous will be 0 for mice and 1 for trackpads
@@ -38,7 +61,7 @@ class ScrollInterceptor {
                 isWheel = false
             }
         }
-        
+
         if isWheel {
             // Invert the scroll event
             if Options.shared.invertVerticalScroll {
@@ -57,14 +80,21 @@ class ScrollInterceptor {
         // pass the event to the system
         return Unmanaged.passUnretained(event)
     }
-    
+
     // Intercept scroll wheel events
     func interceptScroll() {
+        stateLock.lock()
+        guard !isIntercepting else {
+            stateLock.unlock()
+            return
+        }
+        isIntercepting = true
+        stateLock.unlock()
+
+        registerForWakeNotifications()
+
         DispatchQueue.global(qos: .userInteractive).async {
-            var eventTap: CFMachPort?
-            var runLoopSource: CFRunLoopSource?
-            
-            eventTap = CGEvent.tapCreate(
+            guard let eventTap = CGEvent.tapCreate(
                 tap: .cghidEventTap,
                 place: .tailAppendEventTap,
                 options: .defaultTap,
@@ -72,11 +102,109 @@ class ScrollInterceptor {
                 eventsOfInterest: CGEventMask(1 << CGEventType.scrollWheel.rawValue),
                 callback: self.scrollEventCallback,
                 userInfo: nil
-            )
-            runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
-            CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, CFRunLoopMode.commonModes)
-            CGEvent.tapEnable(tap: eventTap!, enable: true)
+            ) else {
+                // Tap creation can fail if accessibility permission was revoked.
+                // Bail out cleanly instead of force-unwrapping and crashing.
+                self.clearInterceptionState()
+                return
+            }
+
+            guard let runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0) else {
+                CFMachPortInvalidate(eventTap)
+                self.clearInterceptionState()
+                return
+            }
+
+            let runLoop = CFRunLoopGetCurrent()
+            self.stateLock.lock()
+            self.eventTap = eventTap
+            self.runLoopSource = runLoopSource
+            self.runLoop = runLoop
+            self.stateLock.unlock()
+
+            CFRunLoopAddSource(runLoop, runLoopSource, CFRunLoopMode.commonModes)
+            CGEvent.tapEnable(tap: eventTap, enable: true)
             CFRunLoopRun()
+
+            // Reached only when the run loop is stopped (e.g. during a restart).
+            CFRunLoopRemoveSource(runLoop, runLoopSource, CFRunLoopMode.commonModes)
+            CFMachPortInvalidate(eventTap)
+            self.clearInterceptionState()
         }
+    }
+
+    /// Re-enables the existing tap. Called from the tap callback when macOS
+    /// disables it, and from the wake-from-sleep notification. If the tap can
+    /// no longer be revived it is torn down and recreated.
+    func reEnableTap() {
+        stateLock.lock()
+        let tap = eventTap
+        stateLock.unlock()
+
+        guard let tap = tap else {
+            // No tap yet (or it was torn down) — (re)start interception.
+            restart()
+            return
+        }
+
+        if !CGEvent.tapIsEnabled(tap: tap) {
+            CGEvent.tapEnable(tap: tap, enable: true)
+        }
+
+        // If it still won't enable, the tap was invalidated during standby;
+        // rebuild it from scratch.
+        if !CGEvent.tapIsEnabled(tap: tap) {
+            restart()
+        }
+    }
+
+    /// Tears down the current run loop (if any) and creates a fresh tap.
+    private func restart() {
+        stateLock.lock()
+        let loop = runLoop
+        stateLock.unlock()
+
+        if let loop = loop {
+            // Causes CFRunLoopRun() in interceptScroll() to return and clean up,
+            // which resets isIntercepting so the relaunch below can proceed.
+            CFRunLoopStop(loop)
+        }
+
+        DispatchQueue.global(qos: .userInteractive).asyncAfter(deadline: .now() + 0.5) {
+            self.interceptScroll()
+        }
+    }
+
+    private func registerForWakeNotifications() {
+        stateLock.lock()
+        let alreadyRegistered = wakeObserver != nil
+        stateLock.unlock()
+        guard !alreadyRegistered else { return }
+
+        let observer = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification,
+            object: nil,
+            queue: nil
+        ) { _ in
+            // The HID subsystem can lag behind wake, so re-enable immediately
+            // and again shortly after to cover the race.
+            ScrollInterceptor.shared.reEnableTap()
+            DispatchQueue.global(qos: .userInteractive).asyncAfter(deadline: .now() + 1.0) {
+                ScrollInterceptor.shared.reEnableTap()
+            }
+        }
+
+        stateLock.lock()
+        wakeObserver = observer
+        stateLock.unlock()
+    }
+
+    private func clearInterceptionState() {
+        stateLock.lock()
+        eventTap = nil
+        runLoopSource = nil
+        runLoop = nil
+        isIntercepting = false
+        stateLock.unlock()
     }
 }


### PR DESCRIPTION
## Problem

On macOS 26 (Tahoe) the app stops working and has to be force quit / the machine rebooted in two situations, reported across several issues:

- **After the Mac sleeps / suspends on low battery and wakes** — scrolling stops and the menu bar item appears frozen (#66, #97, #117).
- **Crash around the preferences/dashboard window**, and stale-permission behaviour after updates (#107).

## Root causes

**1. The `CGEventTap` was never recovered after being disabled.**
macOS disables the tap when a callback times out and across sleep / low-battery standby, delivering one final `kCGEventTapDisabledByTimeout` / `kCGEventTapDisabledByUserInput` event to the callback. The callback ignored those event types, so the tap stayed dead — scroll interception silently stopped and the app looked hung.

**2. Force-unwrap crash reading mouse acceleration.**
`AppDelegate.disableMouseAccel()` did `IOHIDEventSystemClientCopyProperty(client, mouseAccelerationType)!`. That property returns `nil` on macOS 26 (notably right after wake while the HID subsystem is re-initialising). Because this runs on launch, on every `refresh()`, **and when the preferences window closes**, it crashed when opening/closing the dashboard.

## Changes

- **`ScrollInterceptor.swift`**
  - Handle `.tapDisabledByTimeout` / `.tapDisabledByUserInput` in the callback and re-enable the tap.
  - Observe `NSWorkspace.didWakeNotification` and re-enable on wake (immediate + 1s follow-up to cover the HID-not-ready race).
  - Rebuild the tap from scratch if it can no longer be re-enabled (invalidated during standby).
  - Make `interceptScroll()` idempotent and remove the `eventTap!` force-unwrap so a failed `tapCreate` (e.g. revoked accessibility) no longer crashes.
- **`AppDelegate.swift`** — read the IOHID acceleration property defensively (optional + type check) instead of force-unwrapping.
- **`MenuBarItem.swift`** — make the status item idempotent so `refresh()` no longer leaks a new `NSStatusItem` on every preferences close (per #115).

The scroll-detection / inversion logic is unchanged: physical wheels still invert, trackpads are still excluded via `scrollWheelEventIsContinuous`.

## Testing

- Builds clean (Debug + Release, Xcode 26 / macOS 26.5), no new warnings.
- Installed the Release build and confirmed it launches and stays running without crashing (the launch path exercises `refresh() → disableMouseAccel()`).
- Sleep/wake recovery verified by the tap re-enable + wake-notification paths.

Closes #97. Addresses #66, #117.