### PR TITLE
Remove unnecessary Apple Events entitlement

### DIFF
--- a/UnnaturalScrollWheels/Info.plist
+++ b/UnnaturalScrollWheels/Info.plist
@@ -28,8 +28,6 @@
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2020 Theron Tjapkes. All rights reserved.</string>
-	<key>NSAppleEventsUsageDescription</key>
-	<string>Used to request Accessibility permission and manage input for scroll wheel customization.</string>
 	<key>NSMainStoryboardFile</key>
 	<string>Main</string>
 	<key>NSPrincipalClass</key>

--- a/UnnaturalScrollWheels/UnnaturalScrollWheels.entitlements
+++ b/UnnaturalScrollWheels/UnnaturalScrollWheels.entitlements
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>com.apple.security.automation.apple-events</key>
-	<true/>
-</dict>
+<dict/>
 </plist>


### PR DESCRIPTION
Fixes #118

The com.apple.security.automation.apple-events entitlement was added in commit 0ba1b46 but is not used by the application. Having unnecessary entitlements changes the app's code signature, which can cause macOS to revoke Accessibility permissions on update, requiring users to re-grant them even though the app still appears in System Preferences.

This PR removes:
- com.apple.security.automation.apple-events entitlement from UnnaturalScrollWheels.entitlements
- NSAppleEventsUsageDescription from Info.plist

This prevents the code signature from changing unnecessarily between versions, avoiding permissions revocation on update.