### PR TITLE
Fix DMG signing verification gap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,18 +129,17 @@ jobs:
             -format UDZO \
             "$RUNNER_TEMP/$DMG_NAME"
 
-          echo "DMG_PATH=$RUNNER_TEMP/$DMG_NAME" >> "$GITHUB_ENV"
-          echo "DMG_NAME=$DMG_NAME" >> "$GITHUB_ENV"
+       # ── Verify DMG ──────────────────────────────────────────────────
+       - name: Verify DMG
+         run: |
+           echo "=== Verifying app inside DMG ==="
+           hdiutil attach "$DMG_PATH" -nobrowse -readonly
+           codesign --verify --deep --strict --verbose=4 "/Volumes/$APP_NAME/$APP_NAME.app"
+           spctl -a -vv "/Volumes/$APP_NAME/$APP_NAME.app"
+           hdiutil detach "/Volumes/$APP_NAME"
 
-          # Verify the app inside the final DMG
-          echo "=== Verifying app inside DMG ==="
-          hdiutil attach "$DMG_PATH" -nobrowse -readonly
-          codesign --verify --deep --strict --verbose=4 "/Volumes/$APP_NAME/$APP_NAME.app"
-          spctl -a -vv "/Volumes/$APP_NAME/$APP_NAME.app"
-          hdiutil detach "/Volumes/$APP_NAME"
-
-      # ── Notarize DMG ───────────────────────────────────────────────
-      - name: Notarize DMG
+       # ── Notarize DMG ───────────────────────────────────────────────
+       - name: Notarize DMG
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,8 +115,12 @@ jobs:
           # Create a temporary DMG directory with an Applications symlink
           DMG_DIR="$RUNNER_TEMP/dmg"
           mkdir -p "$DMG_DIR"
-          cp -R "$APP_PATH" "$DMG_DIR/"
+          ditto "$APP_PATH" "$DMG_DIR/$APP_NAME.app"
           ln -s /Applications "$DMG_DIR/Applications"
+
+          # Verify the staged app before DMG creation
+          echo "=== Verifying staged app ==="
+          codesign --verify --deep --strict --verbose=4 "$DMG_DIR/$APP_NAME.app"
 
           hdiutil create \
             -volname "$APP_NAME" \
@@ -127,6 +131,13 @@ jobs:
 
           echo "DMG_PATH=$RUNNER_TEMP/$DMG_NAME" >> "$GITHUB_ENV"
           echo "DMG_NAME=$DMG_NAME" >> "$GITHUB_ENV"
+
+          # Verify the app inside the final DMG
+          echo "=== Verifying app inside DMG ==="
+          hdiutil attach "$DMG_PATH" -nobrowse -readonly
+          codesign --verify --deep --strict --verbose=4 "/Volumes/$APP_NAME/$APP_NAME.app"
+          spctl -a -vv "/Volumes/$APP_NAME/$APP_NAME.app"
+          hdiutil detach "/Volumes/$APP_NAME"
 
       # ── Notarize DMG ───────────────────────────────────────────────
       - name: Notarize DMG

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,16 +94,18 @@ jobs:
           # Create a zip for notarization submission
           ditto -c -k --keepParent "$APP_PATH" "$RUNNER_TEMP/$APP_NAME.zip"
 
-           # Submit and wait for notarization (up to 90 minutes)
-           xcrun notarytool submit "$RUNNER_TEMP/$APP_NAME.zip" \
-             --apple-id "$APPLE_ID" \
-             --password "$APPLE_ID_PASSWORD" \
-             --team-id "$APPLE_TEAM_ID" \
-             --wait \
-             --timeout 90m
+          # Submit and wait for notarization (up to 90 minutes)
+          xcrun notarytool submit "$RUNNER_TEMP/$APP_NAME.zip" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_ID_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait \
+            --timeout 90m
 
-           # Staple the notarization ticket
-           xcrun stapler staple "$APP_PATH"
+          # Staple the notarization ticket
+          xcrun stapler staple "$APP_PATH"
+
+      # ── Create DMG ─────────────────────────────────────────────────
       - name: Create DMG
         run: |
           TAG="${GITHUB_REF_NAME}"
@@ -120,33 +122,27 @@ jobs:
           echo "=== Verifying staged app ==="
           codesign --verify --deep --strict --verbose=4 "$DMG_DIR/$APP_NAME.app"
 
-           hdiutil create \
-             -volname "$APP_NAME" \
-             -srcfolder "$DMG_DIR" \
-             -ov \
-             -format UDZO \
-             "$RUNNER_TEMP/$DMG_NAME"
+          hdiutil create \
+            -volname "$APP_NAME" \
+            -srcfolder "$DMG_DIR" \
+            -ov \
+            -format UDZO \
+            "$RUNNER_TEMP/$DMG_NAME"
 
-           echo "DMG_PATH=$RUNNER_TEMP/$DMG_NAME" >> "$GITHUB_ENV"
-           echo "DMG_NAME=$DMG_NAME" >> "$GITHUB_ENV"
-         run: |
-           echo "=== Verifying app inside DMG ==="
-           hdiutil attach "$DMG_PATH" -nobrowse -readonly
-           codesign --verify --deep --strict --verbose=4 "/Volumes/$APP_NAME/$APP_NAME.app"
-           spctl -a -vv "/Volumes/$APP_NAME/$APP_NAME.app"
-           hdiutil detach "/Volumes/$APP_NAME"
+          echo "DMG_PATH=$RUNNER_TEMP/$DMG_NAME" >> "$GITHUB_ENV"
+          echo "DMG_NAME=$DMG_NAME" >> "$GITHUB_ENV"
 
-       # ── Verify DMG ──────────────────────────────────────────────────
-       - name: Verify DMG
-         run: |
-           echo "=== Verifying app inside DMG ==="
-           hdiutil attach "$DMG_PATH" -nobrowse -readonly
-           codesign --verify --deep --strict --verbose=4 "/Volumes/$APP_NAME/$APP_NAME.app"
-           spctl -a -vv "/Volumes/$APP_NAME/$APP_NAME.app"
-           hdiutil detach "/Volumes/$APP_NAME"
+      # ── Verify DMG ──────────────────────────────────────────────────
+      - name: Verify DMG
+        run: |
+          echo "=== Verifying app inside DMG ==="
+          hdiutil attach "$DMG_PATH" -nobrowse -readonly
+          codesign --verify --deep --strict --verbose=4 "/Volumes/$APP_NAME/$APP_NAME.app"
+          spctl -a -vv "/Volumes/$APP_NAME/$APP_NAME.app"
+          hdiutil detach "/Volumes/$APP_NAME"
 
-       # ── Notarize DMG ───────────────────────────────────────────────
-       - name: Notarize DMG
+      # ── Notarize DMG ───────────────────────────────────────────────
+      - name: Notarize DMG
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,13 +94,13 @@ jobs:
           # Create a zip for notarization submission
           ditto -c -k --keepParent "$APP_PATH" "$RUNNER_TEMP/$APP_NAME.zip"
 
-          # Submit and wait for notarization (up to 90 minutes)
-          xcrun notarytool submit "$RUNNER_TEMP/$APP_NAME.zip" \
-            --apple-id "$APPLE_ID" \
-            --password "$APPLE_ID_PASSWORD" \
-            --team-id "$APPLE_TEAM_ID" \
-            --wait \
-            --timeout 90m
+           # Submit and wait for notarization (up to 90 minutes)
+           xcrun notarytool submit "$RUNNER_TEMP/$APP_NAME.zip" \
+             --apple-id "$APPLE_ID" \
+             --password "$APPLE_ID_PASSWORD" \
+             --team-id "$APPLE_TEAM_ID" \
+             --wait \
+             --timeout 90m
 
            # Staple the notarization ticket
            xcrun stapler staple "$APP_PATH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,10 +102,8 @@ jobs:
             --wait \
             --timeout 90m
 
-          # Staple the notarization ticket
-          xcrun stapler staple "$APP_PATH"
-
-      # ── Create DMG ─────────────────────────────────────────────────
+           # Staple the notarization ticket
+           xcrun stapler staple "$APP_PATH"
       - name: Create DMG
         run: |
           TAG="${GITHUB_REF_NAME}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,12 +122,21 @@ jobs:
           echo "=== Verifying staged app ==="
           codesign --verify --deep --strict --verbose=4 "$DMG_DIR/$APP_NAME.app"
 
-          hdiutil create \
-            -volname "$APP_NAME" \
-            -srcfolder "$DMG_DIR" \
-            -ov \
-            -format UDZO \
-            "$RUNNER_TEMP/$DMG_NAME"
+           hdiutil create \
+             -volname "$APP_NAME" \
+             -srcfolder "$DMG_DIR" \
+             -ov \
+             -format UDZO \
+             "$RUNNER_TEMP/$DMG_NAME"
+
+           echo "DMG_PATH=$RUNNER_TEMP/$DMG_NAME" >> "$GITHUB_ENV"
+           echo "DMG_NAME=$DMG_NAME" >> "$GITHUB_ENV"
+         run: |
+           echo "=== Verifying app inside DMG ==="
+           hdiutil attach "$DMG_PATH" -nobrowse -readonly
+           codesign --verify --deep --strict --verbose=4 "/Volumes/$APP_NAME/$APP_NAME.app"
+           spctl -a -vv "/Volumes/$APP_NAME/$APP_NAME.app"
+           hdiutil detach "/Volumes/$APP_NAME"
 
        # ── Verify DMG ──────────────────────────────────────────────────
        - name: Verify DMG


### PR DESCRIPTION
This PR addresses [#118](https://github.com/ther0n/UnnaturalScrollWheels/issues/118) by:

- Replacing `cp -R` with `ditto` for metadata-preserving copy into the DMG staging directory
- Adding verification of the staged app before DMG creation
- Adding verification of the app inside the final DMG after creation

The workflow now verifies the exact artifact that users download, ensuring packaging does not corrupt/invalidate the app signature.